### PR TITLE
Fix missing scrollbar in merge dialog

### DIFF
--- a/src/components/features/MergePeopleDialog.tsx
+++ b/src/components/features/MergePeopleDialog.tsx
@@ -172,7 +172,7 @@ const MergePeopleDialog: React.FC<MergePeopleDialogProps> = ({
         </DialogHeader>
         
         <div className="flex-1 min-h-0"> {/* Wrapper div for ScrollArea */}
- <ScrollArea className="h-full"> {/* ScrollArea takes full height of parent */}
+ <ScrollArea className="h-full overflow-y-auto"> {/* ScrollArea takes full height of parent and allows vertical scrolling */}
  <div className="space-y-4 divide-y divide-border p-4 pr-2"> {/* Content padding (pr-2 to avoid scrollbar overlap) */}
               {renderFieldChoice('name', 'Name', User)}
               {renderFieldChoice('company', 'Company', Building)}


### PR DESCRIPTION
## Summary
- ensure MergePeopleDialog scrolls when content is long

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: cannot find module 'next')*

------
https://chatgpt.com/codex/tasks/task_e_6852870c07d0832aa3626742f0f14c19